### PR TITLE
fix: disable Firebase auto-deployment until secrets configured

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -3,9 +3,10 @@
 
 name: Deploy to Firebase Hosting on merge
 'on':
-  push:
-    branches:
-      - main
+  workflow_dispatch:  # Manual trigger only - uncomment push when Firebase secrets configured
+  # push:
+  #   branches:
+  #     - main
 
 permissions:
   checks: write

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -1,5 +1,7 @@
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+'on':
+  workflow_dispatch:  # Manual trigger only - uncomment pull_request when Firebase secrets configured
+  # pull_request
 
 permissions:
   actions: write


### PR DESCRIPTION
## Problem

Firebase deployment workflows failing on every push to main, causing excessive failed workflow email notifications.

**Error**: Missing `FIREBASE_SERVICE_ACCOUNT_IRISH_WHISTLE_TUNES` secret in GitHub repository settings.

## Solution

Changed both Firebase workflows to manual trigger only (`workflow_dispatch`).

## Changes

**Modified Workflows**:
- `.github/workflows/firebase-hosting-merge.yml` - Disabled auto-deploy on push to main
- `.github/workflows/firebase-hosting-pull-request.yml` - Disabled auto-preview on PRs

**Changes Made**:
```yaml
# Before:
on:
  push:
    branches: [main]

# After:
on:
  workflow_dispatch:  # Manual trigger only
  # push:             # Commented out until secrets configured
  #   branches: [main]
```

## Impact

**Immediate**:
- ✅ Stops failed workflow email spam
- ✅ Preserves workflows for future use
- ✅ No functionality lost (deployment wasn't working anyway)

**Future**:
When ready to enable Firebase deployment:
1. Go to GitHub Settings > Secrets and variables > Actions
2. Add `FIREBASE_SERVICE_ACCOUNT_IRISH_WHISTLE_TUNES` secret
3. Uncomment `push` and `pull_request` triggers
4. Test manually first: Actions > Deploy to Firebase Hosting > Run workflow

## Testing

- ✅ Workflow syntax valid
- ✅ Manual trigger option preserved
- ✅ No breaking changes
- ✅ Build still succeeds
- ✅ Trunk-based checks workflow unaffected

## Trunk-Based Compliance

- ✅ PR size: 11 lines changed (simple fix)
- ✅ Branch age: <30 minutes
- ✅ Single logical change: Disable failing workflows
- ✅ Low risk: Just prevents auto-trigger
- ✅ Branch count: 1/3 (compliant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>